### PR TITLE
Replace reflux with alt

### DIFF
--- a/app/scripts/actions/itemActions.js
+++ b/app/scripts/actions/itemActions.js
@@ -1,21 +1,24 @@
-import Reflux from 'reflux';
+import alt from '../alt';
 
-var ItemActions = Reflux.createActions([
-  'loadItems',
-  'loadItemsSuccess',
-  'loadItemsError'
-]);
+class ItemActions {
+  constructor() {
+    this.generateActions(
+      'loadItemsSuccess',
+      'loadItemsError'
+    );
+  }
 
-ItemActions.loadItems.preEmit = function(data){
-  // make your api call/ async stuff here
-  // we use setTimeout for faking async behaviour here
-  setTimeout(function(){
-    var items = ['Foo', 'Bar', 'Lorem'];
-    ItemActions.loadItemsSuccess(items);
+  loadItems(data) {
+    // make your api call/ async stuff here
+    // we use setTimeout for faking async behaviour here
+    setTimeout(() => {
+      var items = ['Foo', 'Bar', 'Lorem'];
+      this.actions.loadItemsSuccess(items);
 
-    // on error
-    // ItemActions.loadItemsError('an error occured');
-  },500);
-};
+      // on error
+      // ItemActions.loadItemsError('an error occured');
+    }, 500);
+  }
+}
 
-module.exports = ItemActions;
+export default alt.createActions(ItemActions);

--- a/app/scripts/alt.js
+++ b/app/scripts/alt.js
@@ -1,0 +1,2 @@
+import Alt from 'alt';
+export default new Alt();

--- a/app/scripts/components/itemList.jsx
+++ b/app/scripts/components/itemList.jsx
@@ -5,20 +5,16 @@ import ItemActions from '../actions/itemActions';
 var ItemList = React.createClass({
 
   getInitialState() {
-    return {
-      items : [],
-      loading : false,
-      error : false
-    }
+    return ItemStore.getState();
   },
 
   componentDidMount() {
-    this.unsubscribe = ItemStore.listen(this.onStatusChange);
+    ItemStore.listen(this.onStatusChange);
     ItemActions.loadItems();
   },
 
   componentWillUnmount() {
-    this.unsubscribe();
+    ItemStore.unlisten(this.onStatusChange);
   },
 
   onStatusChange(state) {
@@ -38,7 +34,7 @@ var ItemList = React.createClass({
       </div>
     );
   }
-                                     
+
 });
 
 module.exports = ItemList;

--- a/app/scripts/stores/itemStore.js
+++ b/app/scripts/stores/itemStore.js
@@ -1,38 +1,32 @@
-import Reflux from 'reflux';
+import alt from '../alt';
 import ItemActions from '../actions/itemActions';
 
-var ItemStore = Reflux.createStore({
-
-  init() {
+class ItemStore {
+  constructor() {
     this.items = [];
+    this.loading = false;
+    this.error = null;
 
-    this.listenTo(ItemActions.loadItems, this.loadItems);
-    this.listenTo(ItemActions.loadItemsSuccess, this.loadItemsSuccess);
-    this.listenTo(ItemActions.loadItemsError, this.loadItemsError);
-  },
-
-  loadItems() {
-    this.trigger({ 
-      loading: true
-    });
-  },
-
-  loadItemsSuccess(items) {
-    this.items = items;
-
-    this.trigger({ 
-      items : this.items,
-      loading: false
-    });
-  },
-
-  loadItemsError(error) {
-    this.trigger({ 
-      error : error,
-      loading: false
+    this.bindListeners({
+      loadItems: ItemActions.loadItems,
+      loadItemsSuccess: ItemActions.loadItemsSuccess,
+      loadItemsError: ItemActions.loadItemsError
     });
   }
 
-});
+  loadItems() {
+    this.loading = true;
+  }
 
-module.exports = ItemStore;
+  loadItemsSuccess(items) {
+    this.items = items;
+    this.loading = false;
+  }
+
+  loadItemsError(error) {
+    this.error = error;
+    this.loading = false;
+  }
+}
+
+export default alt.createStore(ItemStore, 'ItemStore');

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "webpack": "^1.5.3"
   },
   "dependencies": {
+    "alt": "^0.13.10",
     "react": "^0.12.2",
-    "react-router": "^0.12.0",
-    "reflux": "^0.2.5"
+    "react-router": "^0.12.0"
   }
 }


### PR DESCRIPTION
A bit crazy of a pull request but this does a few things:

* Use ES6 syntax more broadly. Why?

There's ES6 syntax already in use, lets go all out! Things have changed like `export` in favor of commonjs exports, and arrow functions instead of function expressions.

* Replace reflux with alt. Why?

It's built with ES6 in mind, is truly flux, there aren't very many changes. Plus you get some interesting features+mixins to go along with it. The view code looks almost the same, in fact I believe it's better since now you're defining the initial state in the store rather than in the view component.